### PR TITLE
WebDAV: Use appropriate time zone for getlastmodified

### DIFF
--- a/lib/src/webdav/file.dart
+++ b/lib/src/webdav/file.dart
@@ -68,8 +68,8 @@ List<WebDavFile> treeFromWebDavXml(String xmlStr) {
 
     final lastModifiedElements = response.findAllElements('d:getlastmodified');
     final lastModified = lastModifiedElements.single.text != ''
-        ? DateFormat('E, d MMM yyyy HH:mm:ss Z')
-            .parse(lastModifiedElements.single.text)
+        ? DateFormat('E, d MMM yyyy HH:mm:ss', 'en_US')
+            .parseUtc(lastModifiedElements.single.text)
         : null;
 
     final shareTypes = response


### PR DESCRIPTION
Fix for incorrectly parsing the returned date string in local timezone.

The previously used date format does only accept the RFC 822 4-digit time zone
format, but WebDAV returns a HTTP-date[^1] with the following format:

    Sat, 12 Sep 2020 08:45:32 GMT

As far as I can tell the RFC 822 standard[^2] allows a few variations,
and Nextcloud seems to always return GMT. This time zone part was ignored by
the lenient parser, resulting in a DateTime object in local time.

This commit changes the parser so that the date string is always parsed
in UTC, and the English locale which seems like a much safer default than the
implicit client locale.

[^1]: http://www.webdav.org/specs/rfc2518.html#PROPERTY_getlastmodified
[^2]: https://tools.ietf.org/html/rfc822#section-5