### PR TITLE
Additional WebDAV features: status, get properties, set properties, filter

### DIFF
--- a/lib/src/webdav/client.dart
+++ b/lib/src/webdav/client.dart
@@ -254,25 +254,33 @@ class WebDavClient {
   }
 
   /// Move a file from [sourcePath] to [destinationPath]
-  Future move(String sourcePath, String destinationPath) async {
-    await _network.send(
+  ///
+  /// Throws a [RequestException] if the move operation failed.
+  Future<http.Response> move(String sourcePath, String destinationPath,
+      {bool overwrite = false}) {
+    return _network.send(
       'MOVE',
       _getUrl(sourcePath),
-      [200, 201],
+      [200, 201, 204],
       headers: {
         'Destination': _getUrl(destinationPath),
+        'Overwrite': overwrite ? 'T' : 'F',
       },
     );
   }
 
   /// Copy a file from [sourcePath] to [destinationPath]
-  Future copy(String sourcePath, String destinationPath) async {
-    await _network.send(
+  ///
+  /// Throws a [RequestException] if the copy operation failed.
+  Future<http.Response> copy(String sourcePath, String destinationPath,
+      {bool overwrite = false}) {
+    return _network.send(
       'COPY',
       _getUrl(sourcePath),
-      [200, 201],
+      [200, 201, 204],
       headers: {
         'Destination': _getUrl(destinationPath),
+        'Overwrite': overwrite ? 'T' : 'F',
       },
     );
   }

--- a/lib/src/webdav/client.dart
+++ b/lib/src/webdav/client.dart
@@ -34,6 +34,15 @@ class WebDavClient {
     return '$_baseUrl/remote.php/dav/$path';
   }
 
+  /// returns the WebDAV capabilities of the server
+  Future<WebDavStatus> status() async {
+    final response = await _network.send('OPTIONS', _getUrl('/'), [200]);
+    final davCapabilities = response.headers['dav'] ?? '';
+    final davSearchCapabilities = response.headers['dasl'] ?? '';
+    return WebDavStatus(davCapabilities.split(',').map((e) => e.trim()).toSet(),
+        davSearchCapabilities.split(',').map((e) => e.trim()).toSet());
+  }
+
   /// make a dir with [path] under current dir
   Future<http.Response> mkdir(String path, [bool safe = true]) {
     final expectedCodes = [
@@ -136,4 +145,20 @@ class WebDavClient {
       },
     );
   }
+}
+
+/// WebDAV server status.
+class WebDavStatus {
+  /// Creates a new WebDavStatus.
+  WebDavStatus(
+    this.capabilities,
+    this.searchCapabilities,
+  );
+
+  /// DAV capabilities as advertised by the server in the 'dav' header.
+  Set<String> capabilities;
+
+  /// DAV search and locating capabilities as advertised by the server in the
+  /// 'dasl' header.
+  Set<String> searchCapabilities;
 }

--- a/lib/src/webdav/client.dart
+++ b/lib/src/webdav/client.dart
@@ -30,41 +30,9 @@ class WebDavClient {
     'DAV:': 'd',
     'http://owncloud.org/ns': 'oc',
     'http://nextcloud.org/ns': 'nc',
+    'http://open-collaboration-services.org/ns': 'ocs',
+    'http://open-cloud-mesh.org/ns': 'ocm',
     'http://sabredav.org/ns': 's', // mostly used in error responses
-  };
-
-  /// All WebDAV props supported by Nextcloud, in prefix form
-  static const Set<String> allProps = {
-    'd:getlastmodified',
-    'd:getetag',
-    'd:getcontenttype',
-    'd:resourcetype',
-    'd:getcontentlength',
-    'oc:id',
-    'oc:fileid',
-    'oc:tags', // editable
-    'oc:favorite', // editable, reportable
-    'oc:systemtag', // reportable
-    'oc:circle', // reportable
-    'oc:comments-href',
-    'oc:comments-count',
-    'oc:comments-unread',
-    'oc:downloadURL',
-    'oc:owner-id',
-    'oc:owner-display-name',
-    'oc:share-types',
-    'nc:sharees',
-    'nc:note',
-    'oc:checksums',
-    'oc:size',
-    'oc:permissions',
-    'nc:data-fingerprint',
-    'nc:has-preview',
-    'nc:mount-type',
-    'nc:is-encrypted',
-    'nc:metadata_etag', // editable
-    'nc:upload_time', // editable
-    'nc:creation_time', // editable
   };
 
   /// get url from given [path]
@@ -158,11 +126,11 @@ class WebDavClient {
   /// Optionally populates the given [props] on the returned files.
   Future<List<WebDavFile>> ls(String remotePath,
       {Set<String> props = const {
-        'd:getlastmodified',
-        'd:getcontentlength',
-        'd:getcontenttype',
-        'oc:id',
-        'oc:share-types',
+        WebDavProps.davContentLength,
+        WebDavProps.davContentType,
+        WebDavProps.davLastModified,
+        WebDavProps.ocId,
+        WebDavProps.ocShareTypes,
       }}) async {
     final builder = XmlBuilder();
     builder
@@ -220,7 +188,7 @@ class WebDavClient {
   /// specified via [props].
   Future<WebDavFile> getProps(
     String remotePath, {
-    Set<String> props = WebDavClient.allProps,
+    Set<String> props = WebDavProps.all,
   }) async {
     final builder = XmlBuilder();
     builder
@@ -310,4 +278,191 @@ class WebDavStatus {
   /// DAV search and locating capabilities as advertised by the server in the
   /// 'dasl' header.
   Set<String> searchCapabilities;
+}
+
+/// Mapping of all WebDAV properties.
+class WebDavProps {
+  /// All WebDAV props supported by Nextcloud, in prefix form
+  static const all = {
+    davContentLength,
+    davContentType,
+    davETag,
+    davLastModified,
+    davResourceType,
+    ncCreationTime,
+    ncDataFingerprint,
+    ncHasPreview,
+    ncIsEncrypted,
+    ncMetadataETag,
+    ncMountType,
+    ncNote,
+    ncRichWorkspace,
+    ncShareees,
+    ncUploadTime,
+    ocChecksums,
+    ocCircle,
+    ocCommentsCount,
+    ocCommentsHref,
+    ocCommentsUnread,
+    ocDownloadURL,
+    ocFavorite,
+    ocFileId,
+    ocId,
+    ocOwnerDisplayName,
+    ocOwnerId,
+    ocPermissions,
+    ocShareTypes,
+    ocSize,
+    ocSystemTag,
+    ocTags,
+  };
+
+  /// Contains the Last-Modified header value  .
+  static const davLastModified = 'd:getlastmodified';
+
+  /// Contains the ETag header value.
+  static const davETag = 'd:getetag';
+
+  /// Contains the Content-Type header value.
+  static const davContentType = 'd:getcontenttype';
+
+  /// Specifies the nature of the resource.
+  static const davResourceType = 'd:resourcetype';
+
+  /// Contains the Content-Length header.
+  static const davContentLength = 'd:getcontentlength';
+
+  /// The fileid namespaced by the instance id, globally unique
+  static const ocId = 'oc:id';
+
+  /// The unique id for the file within the instance
+  static const ocFileId = 'oc:fileId';
+
+  /// List of user specified tags. Can be modified.
+  static const ocTags = 'oc:tags';
+
+  /// Whether a resource is tagged as favorite.
+  /// Can be modified and reported on with list-files.
+  static const ocFavorite = 'oc:favorite';
+
+  /// List of collaborative tags. Can be reported on with list-files.
+  ///
+  /// Valid system tags are:
+  /// - oc:id
+  /// - oc:display-name
+  /// - oc:user-visible
+  /// - oc:user-assignable
+  /// - oc:groups
+  /// - oc:can-assign
+  static const ocSystemTag = 'oc:systemtag';
+
+  /// Can be reported on with list-files.
+  static const ocCircle = 'oc:circle';
+
+  /// Link to the comments for this resource.
+  static const ocCommentsHref = 'oc:comments-href';
+
+  /// Number of comments.
+  static const ocCommentsCount = 'oc:comments-count';
+
+  /// Number of unread comments.
+  static const ocCommentsUnread = 'oc:comments-unread';
+
+  /// Download URL.
+  static const ocDownloadURL = 'oc:downloadURL';
+
+  /// The user id of the owner of a shared file
+  static const ocOwnerId = 'oc:owner-id';
+
+  /// The display name of the owner of a shared file
+  static const ocOwnerDisplayName = 'oc:owner-display-name';
+
+  /// Share types of this file.
+  ///
+  /// Returns a list of share-type objects where:
+  /// - 0: user share
+  /// - 1: group share
+  /// - 2: usergroup share
+  /// - 3: public link
+  /// - 4: email
+  /// - 5: contact
+  /// - 6: remote (federated cloud)
+  /// - 7: circle
+  /// - 8: guest
+  /// - 9: remote group
+  /// - 10: room (talk conversation)
+  /// - 11: userroom
+  /// See also [OCS Share API](https://docs.nextcloud.com/server/19/developer_manual/client_apis/OCS/ocs-share-api.html)
+  static const ocShareTypes = 'oc:share-types';
+
+  /// List of users this file is shared with.
+  ///
+  /// Returns a list of sharee objects with:
+  /// - id
+  /// - display-name
+  /// - type (share type)
+  static const ncShareees = 'nc:sharees';
+
+  /// Share note.
+  static const ncNote = 'nc:note';
+
+  /// Checksums as provided during upload.
+  ///
+  /// Returns a list of checksum objects.
+  static const ocChecksums = 'oc:checksums';
+
+  /// Unlike [[davContentLength]], this property also works for folders
+  /// reporting the size of everything in the folder.
+  static const ocSize = 'oc:size';
+
+  /// WebDAV permissions:
+  ///
+  /// - S: shared
+  /// - R: shareable
+  /// - M: mounted
+  /// - G: readable
+  /// - D: deletable
+  /// - NV: updateable, renameable, moveble
+  /// - W: updateable (file)
+  /// - CK: creatable
+  static const ocPermissions = 'oc:permissions';
+
+  /// Nextcloud CRUDS permissions:
+  ///
+  /// - 1: read
+  /// - 2: update
+  /// - 4: create
+  /// - 8: delete
+  /// - 16: share
+  /// - 31: all
+  static const ocsSharePermissions = 'ocs:share-permissions';
+
+  /// OCM permissions:
+  ///
+  /// - share
+  /// - read
+  /// - write
+  static const ocmSharePermissions = 'ocm:share-permissions';
+
+  /// system data-fingerprint
+  static const ncDataFingerprint = 'nc:data-fingerprint';
+
+  /// Whether a preview is available.
+  static const ncHasPreview = 'nc:has-preview';
+
+  /// Mount type, e.g. global, group, user, personal, shared, shared-root, external
+  static const ncMountType = 'nc:mount-type';
+
+  /// Is this file is encrypted, 0 for false or 1 for true.
+  static const ncIsEncrypted = 'nc:is-encrypted';
+
+  static const ncMetadataETag = 'nc:metadata_etag';
+
+  /// Date this file was uploaded.
+  static const ncUploadTime = 'nc:upload_time';
+
+  /// Creation time of the file as provided during upload.
+  static const ncCreationTime = 'nc:creation_time';
+
+  static const ncRichWorkspace = 'nc:rich-workspace';
 }

--- a/lib/src/webdav/client.dart
+++ b/lib/src/webdav/client.dart
@@ -153,6 +153,7 @@ class WebDavClient {
         'd:getlastmodified',
         'd:getcontentlength',
         'd:getcontenttype',
+        'oc:id',
         'oc:share-types',
       }}) async {
     final builder = XmlBuilder();

--- a/lib/src/webdav/file.dart
+++ b/lib/src/webdav/file.dart
@@ -51,6 +51,26 @@ class WebDavFile {
   /// Whether this file is marked as favorite.
   bool favorite = false;
 
+  /// Other properties, mapped by their prefixed name name
+  final Map<String, String> _otherProps = {};
+
+  /// Additional namespace-prefix mappings for custom properties
+  final Map<String, String> _otherNamespaces = {};
+
+  /// Add an additional property by [name] and [value]
+  void addOtherProp(xml.XmlName name, String value) {
+    _otherNamespaces[name.namespaceUri] = name.prefix;
+    _otherProps[name.qualified] = value;
+  }
+
+  /// Lookup an additional property by [name] and [namespaceUri]
+  String getOtherProp(String name, String namespaceUri) {
+    final localName = xml.XmlName.fromString(name).local;
+    // find correct prefix
+    final prefix = _otherNamespaces[namespaceUri];
+    return _otherProps['$prefix:$localName'];
+  }
+
   /// Returns the decoded name of the file / folder without the whole path
   String get name {
     // normalised path (remove trailing slash)
@@ -126,7 +146,8 @@ void _handleProp(xml.XmlElement prop, WebDavFile file) {
           DateTime.fromMillisecondsSinceEpoch(int.parse(prop.text) * 1000);
       break;
     default:
-      print('Ignoring unsupported prop: ${prop.name} - ${prop.text}');
+      // store with fully qualified name
+      file.addOtherProp(prop.name, prop.text);
   }
 }
 

--- a/lib/src/webdav/file.dart
+++ b/lib/src/webdav/file.dart
@@ -1,4 +1,5 @@
 import 'package:intl/intl.dart';
+import 'package:nextcloud/nextcloud.dart';
 import 'package:xml/xml.dart' as xml;
 
 /// WebDavFile class
@@ -94,54 +95,54 @@ void _handleProp(xml.XmlElement prop, WebDavFile file) {
   }
 
   switch (prop.name.qualified) {
-    case 'd:getcontenttype':
+    case WebDavProps.davContentType:
       file.mimeType = prop.text;
       break;
-    case 'd:getcontentlength':
+    case WebDavProps.davContentLength:
       file.size = int.parse(prop.text);
       break;
-    case 'd:getlastmodified':
+    case WebDavProps.davLastModified:
       file.lastModified =
           DateFormat('E, d MMM yyyy HH:mm:ss', 'en_US').parseUtc(prop.text);
       break;
-    case 'd:resourcetype':
+    case WebDavProps.davResourceType:
       file.isCollection = prop.getElement('d:collection') != null;
       break;
-    case 'oc:id':
+    case WebDavProps.ocId:
       file.id = prop.text;
       break;
-    case 'oc:fileid':
+    case WebDavProps.ocFileId:
       file.fileId = prop.text;
       break;
-    case 'oc:favorite':
+    case WebDavProps.ocFavorite:
       file.favorite = prop.text == '1';
       break;
-    case 'oc:owner-id':
+    case WebDavProps.ocOwnerId:
       file.ownerId = prop.text;
       break;
-    case 'oc:owner-display-name':
+    case WebDavProps.ocOwnerDisplayName:
       file.ownerDisplay = prop.text;
       break;
-    case 'oc:share-types':
+    case WebDavProps.ocShareTypes:
       file.shareTypes = prop
           .findElements('oc:share-type')
           .map((element) => int.parse(element.text))
           .toList();
       break;
-    case 'nc:sharees':
+    case WebDavProps.ncShareees:
       file.sharees = prop.findAllElements('nc:id').map((e) => e.text).toList();
       break;
-    case 'oc:note':
+    case WebDavProps.ncNote:
       file.note = prop.text;
       break;
-    case 'oc:size':
+    case WebDavProps.ocSize:
       file.size = int.parse(prop.text);
       break;
-    case 'nc:creation_time':
+    case WebDavProps.ncCreationTime:
       file.createdDate =
           DateTime.fromMillisecondsSinceEpoch(int.parse(prop.text) * 1000);
       break;
-    case 'nc:upload_time':
+    case WebDavProps.ncUploadTime:
       file.uploadedDate =
           DateTime.fromMillisecondsSinceEpoch(int.parse(prop.text) * 1000);
       break;

--- a/lib/src/webdav/file.dart
+++ b/lib/src/webdav/file.dart
@@ -15,6 +15,9 @@ class WebDavFile {
   /// The unique id for the file within the instance
   String fileId;
 
+  /// Whether this is a collection resource type
+  bool isCollection = false;
+
   // ignore: public_member_api_docs
   String mimeType;
 
@@ -56,7 +59,7 @@ class WebDavFile {
   }
 
   /// Returns if the file is a directory
-  bool get isDirectory => path.endsWith('/');
+  bool get isDirectory => path.endsWith('/') || isCollection;
 
   @override
   String toString() =>
@@ -65,7 +68,7 @@ class WebDavFile {
 }
 
 void _handleProp(xml.XmlElement prop, WebDavFile file) {
-  if (prop.text.isEmpty) {
+  if (prop.children.isEmpty && prop.text.isEmpty) {
     // Ignore empty properties
     return;
   }
@@ -80,6 +83,9 @@ void _handleProp(xml.XmlElement prop, WebDavFile file) {
     case 'd:getlastmodified':
       file.lastModified =
           DateFormat('E, d MMM yyyy HH:mm:ss', 'en_US').parseUtc(prop.text);
+      break;
+    case 'd:resourcetype':
+      file.isCollection = prop.getElement('d:collection') != null;
       break;
     case 'oc:id':
       file.id = prop.text;

--- a/lib/src/webdav/file.dart
+++ b/lib/src/webdav/file.dart
@@ -173,3 +173,17 @@ List<WebDavFile> treeFromWebDavXml(String xmlStr) {
   }
   return tree.cast<WebDavFile>()..removeAt(0);
 }
+
+/// Returns false if some updates have failed.
+bool checkUpdateFromWebDavXml(String xmlStr) {
+  final xmlDocument = xml.XmlDocument.parse(xmlStr);
+  final response = xmlDocument.findAllElements('d:response').single;
+  final propStatElements = response.findElements('d:propstat');
+  for (final propStat in propStatElements) {
+    final status = propStat.getElement('d:status').text;
+    if (!status.contains('200')) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/lib/src/webdav/file.dart
+++ b/lib/src/webdav/file.dart
@@ -171,7 +171,7 @@ List<WebDavFile> treeFromWebDavXml(String xmlStr) {
   for (final response in xmlDocument.findAllElements('d:response')) {
     tree.add(_fromWebDavXml(response));
   }
-  return tree.cast<WebDavFile>()..removeAt(0);
+  return tree.cast<WebDavFile>();
 }
 
 /// Returns false if some updates have failed.

--- a/test/nextcloud_test.dart
+++ b/test/nextcloud_test.dart
@@ -229,15 +229,15 @@ void main() {
       final id = response.headers['oc-fileid'];
 
       // Favorite file
-      await client.webDav.updateProps(path, {'oc:favorite': '1'});
+      await client.webDav.updateProps(path, {WebDavProps.ocFavorite: '1'});
 
       // Find favorites
       final files = await client.webDav.filter(config.testDir, {
-        'oc:favorite': '1',
+        WebDavProps.ocFavorite: '1',
       }, props: {
-        'oc:id',
-        'oc:fileid',
-        'oc:favorite',
+        WebDavProps.ocId,
+        WebDavProps.ocFileId,
+        WebDavProps.ocFavorite,
       });
       final file = files.singleWhere((e) => e.name == 'filter-test.txt');
       expect(file.favorite, isTrue);
@@ -247,8 +247,10 @@ void main() {
       final createdDate = DateTime.utc(1971, 2, 1);
       final createdEpoch = createdDate.millisecondsSinceEpoch / 1000;
       final path = '${config.testDir}/prop-test.txt';
-      final updated = await client.webDav.updateProps(
-          path, {'oc:favorite': '1', 'nc:creation_time': '$createdEpoch'});
+      final updated = await client.webDav.updateProps(path, {
+        WebDavProps.ocFavorite: '1',
+        WebDavProps.ncCreationTime: '$createdEpoch'
+      });
       expect(updated, isTrue);
 
       final file = await client.webDav.getProps(path);

--- a/test/nextcloud_test.dart
+++ b/test/nextcloud_test.dart
@@ -153,7 +153,9 @@ void main() {
       expect(file.isDirectory, false);
       expect(file.name, 'prop-test.txt');
       expect(file.lastModified.isAfter(startTime), isTrue,
-          reason: 'Expected $startTime < ${file.lastModified}');
+          reason: 'Expected lastModified: $startTime < ${file.lastModified}');
+      expect(file.uploadedDate.isAfter(startTime), isTrue,
+          reason: 'Expected uploadedDate: $startTime < ${file.uploadedDate}');
       expect(file.mimeType, 'text/plain');
       expect(file.path, path);
       expect(file.shareTypes, isEmpty);
@@ -168,7 +170,7 @@ void main() {
       expect(file.mimeType, isNull);
       expect(file.path, '$path/');
       expect(file.shareTypes, isEmpty);
-      expect(file.size, 0);
+      expect(file.size, greaterThan(0));
     });
   });
   group('Talk', () {

--- a/test/nextcloud_test.dart
+++ b/test/nextcloud_test.dart
@@ -173,6 +173,20 @@ void main() {
       expect(file.shareTypes, isEmpty);
       expect(file.size, greaterThan(0));
     });
+    test('Set properties', () async {
+      final createdDate = DateTime.utc(1971, 2, 1);
+      final createdEpoch = createdDate.millisecondsSinceEpoch / 1000;
+      final path = '${config.testDir}/prop-test.txt';
+      final updated = await client.webDav.updateProps(
+          path, {'oc:favorite': '1', 'nc:creation_time': '$createdEpoch'});
+      expect(updated, isTrue);
+
+      final file = await client.webDav.getProps(path);
+      expect(file.favorite, isTrue);
+      expect(file.createdDate.isAtSameMomentAs(createdDate), isTrue,
+          reason: 'Expected same time: $createdDate = ${file.createdDate}');
+      expect(file.uploadedDate, isNotNull);
+    });
   });
   group('Talk', () {
     test('Signaling', () async {

--- a/test/nextcloud_test.dart
+++ b/test/nextcloud_test.dart
@@ -122,26 +122,66 @@ void main() {
       expect(file.size, data.length);
     });
     test('Copy file', () async {
-      expect(
-          await client.webDav.copy(
-            '${config.testDir}/test.txt',
-            '${config.testDir}/test2.txt',
-          ),
-          null);
+      final response = await client.webDav.copy(
+        '${config.testDir}/test.txt',
+        '${config.testDir}/test2.txt',
+      );
+      expect(response.statusCode, 201);
       final files = await client.webDav.ls(config.testDir);
       expect(files.where((f) => f.name == 'test.txt'), hasLength(1));
       expect(files.where((f) => f.name == 'test2.txt'), hasLength(1));
     });
-    test('Move file', () async {
+    test('Copy file (no overwrite)', () async {
+      final path = '${config.testDir}/copy-test.txt';
+      final data = utf8.encode('WebDAV copytest');
+      await client.webDav.upload(data, path);
+
       expect(
-          await client.webDav.move(
-            '${config.testDir}/test2.txt',
-            '${config.testDir}/test3.txt',
-          ),
-          null);
+          () => client.webDav.copy(
+              '${config.testDir}/test.txt', '${config.testDir}/copy-test.txt',
+              overwrite: false),
+          throwsA(predicate((e) => e.statusCode == 412)));
+    });
+    test('Copy file (overwrite)', () async {
+      final path = '${config.testDir}/copy-test.txt';
+      final data = utf8.encode('WebDAV copytest');
+      await client.webDav.upload(data, path);
+
+      final response = await client.webDav.copy(
+          '${config.testDir}/test.txt', '${config.testDir}/copy-test.txt',
+          overwrite: true);
+      expect(response.statusCode, 204);
+    });
+    test('Move file', () async {
+      final response = await client.webDav.move(
+        '${config.testDir}/test2.txt',
+        '${config.testDir}/test3.txt',
+      );
+      expect(response.statusCode, 201);
       final files = await client.webDav.ls(config.testDir);
       expect(files.where((f) => f.name == 'test2.txt'), isEmpty);
       expect(files.where((f) => f.name == 'test3.txt'), hasLength(1));
+    });
+    test('Move file (no overwrite)', () async {
+      final path = '${config.testDir}/move-test.txt';
+      final data = utf8.encode('WebDAV movetest');
+      await client.webDav.upload(data, path);
+
+      expect(
+          () => client.webDav.move(
+              '${config.testDir}/test.txt', '${config.testDir}/move-test.txt',
+              overwrite: false),
+          throwsA(predicate((e) => e.statusCode == 412)));
+    });
+    test('Move file (overwrite)', () async {
+      final path = '${config.testDir}/move-test.txt';
+      final data = utf8.encode('WebDAV movetest');
+      await client.webDav.upload(data, path);
+
+      final response = await client.webDav.move(
+          '${config.testDir}/test.txt', '${config.testDir}/move-test.txt',
+          overwrite: true);
+      expect(response.statusCode, 204);
     });
     test('Get file properties', () async {
       final startTime = DateTime.now().subtract(Duration(seconds: 2));

--- a/test/nextcloud_test.dart
+++ b/test/nextcloud_test.dart
@@ -57,6 +57,11 @@ void main() {
     });
   });
   group('WebDav', () {
+    test('Get status', () async {
+      final status = await client.webDav.status();
+      expect(status.capabilities, containsAll(['1', '3', 'access-control']));
+      expect(status.searchCapabilities, contains('<DAV:basicsearch>'));
+    });
     test('Clean test environment', () async {
       expect(
           await (() async {

--- a/test/nextcloud_test.dart
+++ b/test/nextcloud_test.dart
@@ -165,6 +165,7 @@ void main() {
       final path = Uri.parse(config.testDir);
       final file = await client.webDav.getProps(path.toString());
       expect(file.isDirectory, true);
+      expect(file.isCollection, true);
       expect(file.name, path.pathSegments.last);
       expect(file.lastModified, isNotNull);
       expect(file.mimeType, isNull);

--- a/test/nextcloud_test.dart
+++ b/test/nextcloud_test.dart
@@ -173,6 +173,27 @@ void main() {
       expect(file.shareTypes, isEmpty);
       expect(file.size, greaterThan(0));
     });
+    test('Filter files', () async {
+      final path = '${config.testDir}/filter-test.txt';
+      final data = utf8.encode('WebDAV filtertest');
+      final response = await client.webDav.upload(data, path);
+      final id = response.headers['oc-fileid'];
+
+      // Favorite file
+      await client.webDav.updateProps(path, {'oc:favorite': '1'});
+
+      // Find favorites
+      final files = await client.webDav.filter(config.testDir, {
+        'oc:favorite': '1',
+      }, props: {
+        'oc:id',
+        'oc:fileid',
+        'oc:favorite',
+      });
+      final file = files.singleWhere((e) => e.name == 'filter-test.txt');
+      expect(file.favorite, isTrue);
+      expect(file.id, id);
+    });
     test('Set properties', () async {
       final createdDate = DateTime.utc(1971, 2, 1);
       final createdEpoch = createdDate.millisecondsSinceEpoch / 1000;


### PR DESCRIPTION
Hi,

I've implemented some additional WebDAV features that I needed for my project.

New features:
* Expose additional fields on `WebDavFile`, including the unique file ID
* `status` method to query WebDAV server capabilities; can also be used to check the connection to the server
* `getProps` method to retrieve selected (or all) properties for a resource
* `updateProps` method to set properties on a resource
* `filter` method to run the [filter-files](https://docs.nextcloud.com/server/19/developer_manual/client_apis/WebDAV/basic.html#listing-favorites) report, e.g. to list all favourites of a user
* Support for properties with custom namespaces on `ls`, `getProps` and `updateProps`

Improvements:
* Ability to specify which properties should be requested during `ls`
* Improve directory detection to work with collection resources
* Add optional `overwrite` parameter to `copy`and `move`

I don't think there are any backwards incompatible (breaking) changes in here.

The commits are pretty well organised but I can also split this up into separate pull requests if you prefer smaller changesets.