### PR TITLE
Fixed webDav property for fileid

### DIFF
--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -150,9 +150,6 @@ class RequestException implements Exception {
   // ignore: public_member_api_docs
   String method;
 
-  @override
-  String toString() =>
-      'RequestException{method: $method, url: $url, statusCode: $statusCode, body: $body}';
 }
 
 /// Organizes the requests

--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -149,6 +149,10 @@ class RequestException implements Exception {
 
   // ignore: public_member_api_docs
   String method;
+
+  @override
+  String toString() =>
+      'RequestException{method: $method, url: $url, statusCode: $statusCode, body: $body}';
 }
 
 /// Organizes the requests

--- a/lib/src/webdav/client.dart
+++ b/lib/src/webdav/client.dart
@@ -471,7 +471,7 @@ class WebDavProps {
   static const ocId = 'oc:id';
 
   /// The unique id for the file within the instance
-  static const ocFileId = 'oc:fileId';
+  static const ocFileId = 'oc:fileid';
 
   /// List of user specified tags. Can be modified.
   static const ocTags = 'oc:tags';


### PR DESCRIPTION
E.g., calling `client.webDav.ls(widget.directory.path, props: WebDavProps.all);` returned `WebDavFile`s where `fileId` was not initialized because the xml property was not correct:

 **wrong**: `ocFileId = 'oc:fileId'`, 
**correct**: `ocFileId = 'oc:fileid'`.

See [documentation](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/WebDAV/basic.html).

PS: Fixes #46