### PR TITLE
Added `toString` to `RequestException`

### DIFF
--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -150,9 +150,6 @@ class RequestException implements Exception {
   // ignore: public_member_api_docs
   String method;
 
-  @override
-  String toString() =>
-      'RequestException{method: $method, url: $url, statusCode: $statusCode, body: $body}';
 }
 
 /// Organizes the requests

--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -150,6 +150,9 @@ class RequestException implements Exception {
   // ignore: public_member_api_docs
   String method;
 
+  @override
+  String toString() =>
+      'RequestException{method: $method, url: $url, statusCode: $statusCode, body: $body}';
 }
 
 /// Organizes the requests

--- a/lib/src/network.dart
+++ b/lib/src/network.dart
@@ -149,6 +149,10 @@ class RequestException implements Exception {
 
   // ignore: public_member_api_docs
   String method;
+
+  @override
+  String toString() =>
+      'RequestException{method: $method, url: $url, statusCode: $statusCode, body: $body}';
 }
 
 /// Organizes the requests

--- a/lib/src/webdav/client.dart
+++ b/lib/src/webdav/client.dart
@@ -471,7 +471,7 @@ class WebDavProps {
   static const ocId = 'oc:id';
 
   /// The unique id for the file within the instance
-  static const ocFileId = 'oc:fileid';
+  static const ocFileId = 'oc:fileId';
 
   /// List of user specified tags. Can be modified.
   static const ocTags = 'oc:tags';

--- a/lib/src/webdav/client.dart
+++ b/lib/src/webdav/client.dart
@@ -471,7 +471,7 @@ class WebDavProps {
   static const ocId = 'oc:id';
 
   /// The unique id for the file within the instance
-  static const ocFileId = 'oc:fileId';
+  static const ocFileId = 'oc:fileid';
 
   /// List of user specified tags. Can be modified.
   static const ocTags = 'oc:tags';


### PR DESCRIPTION
This improves usability of the library by providing necessary information for fixing the cause of the exception.

**Before**:
```
Unhandled exception:
Instance of 'RequestException'
[...]
```

**After**:
```
Unhandled exception:
RequestException{method: GET, url: http://example.com, statusCode: 500, body: myBody}
[...]
```